### PR TITLE
docs(release): codify version discipline for release triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,11 @@ These instructions apply to any automated or assisted work in this repository.
 - Assume squash merge is the default strategy. In that model, the PR title is the authoritative message for release automation.
 - Keep commit subjects concise, imperative, and release-readable. Avoid vague subjects such as `updates`, `misc fixes`, or `changes`.
 - Do not mix unrelated change types in one commit or one PR when that would obscure release notes.
-- If a change is internal-only, avoid presenting it as a user-facing `feat` or `fix` unless it should affect versioning and release notes.
-- For release process details, see `docs/releasing.md`.
+- Choose the commit type by what the change actually affects. Only changes that alter the shipped `maskdump` binary warrant a release:
+  - Binary-affecting changes (`*.go` except `*_test.go`, `go.mod`, `go.sum`) use `feat:`, `fix:`, or `perf:` and trigger a release.
+  - Everything else — CI and workflows (`.github/`), documentation (`docs/`, `*.md`), tests and benchmarks (`*_test.go`, `testdata/`), tooling (`Makefile`, `tools/`), example configs — uses `ci:`, `docs:`, `test:`, `build:`, or `chore:` and must not trigger a release.
+- Release Please classifies commits by type only; the scope is ignored. `fix(ci): ...` is still a `fix` and produces a patch release, so never use `feat` or `fix` for infrastructure-only changes — write `ci(release): ...` instead.
+- For release process details, see `docs/releasing.md` -> "Version Discipline: What Warrants a Release".
 
 ## Required Validation After Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,14 @@ Do not consider the task complete until these checks have been run successfully,
 - Prefer `Squash and merge`.
 - Before confirming a squash merge, ensure the final commit title matches the PR title exactly.
 - Avoid merge methods that change the release-significant commit message unexpectedly.
+- When asked to create a PR, prefer GitHub CLI over manual GitHub UI entry so the title is explicit and reproducible.
+- When creating a PR with `gh`, always pass the title explicitly with a Conventional Commit message instead of relying on branch-name-derived defaults.
+
+Preferred pattern:
+
+```bash
+gh pr create --repo intaro/maskdump --title "type(scope): short summary" --body "..."
+```
 
 ### Release Please Rules
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,7 +40,29 @@ Examples from the current baseline `v0.1.5`:
 - next merged releasable change is `feat(config): support yaml config` -> `v0.2.0`
 - next merged releasable change is `feat!: remove legacy config fields` -> `v1.0.0`
 
-Documentation-only or maintenance-only changes such as `docs:`, `test:`, `ci:`, and `chore:` should still use Conventional Commits, but they should not be relied on as the primary trigger for a release.
+Documentation-only or maintenance-only changes such as `docs:`, `test:`, `ci:`, and `chore:` do not trigger a release. See "Version Discipline: What Warrants a Release" below for how to pick the type.
+
+## Version Discipline: What Warrants a Release
+
+The version tag `vX.Y.Z` tracks the **shipped `maskdump` binary** only. Pick a commit type by *what the change actually affects*, not by how big it feels:
+
+- **Binary code and dependencies** — anything that changes the compiled `maskdump` binary or its behavior: `*.go` files (excluding `*_test.go`), `go.mod`, `go.sum`. Use `feat:` (new capability -> minor) or `fix:`/`perf:` (correction or optimization -> patch). These cut a new version and tag.
+- **Everything else** — CI and workflows (`.github/`), documentation (`docs/`, `README.md`, `*.md`), tests and benchmarks (`*_test.go`, `testdata/`), tooling (`Makefile`, `tools/`), and example configs (`*.conf.example`). Use `ci:`, `docs:`, `test:`, `build:`, or `chore:`. These do **not** bump the version: the released binary is unchanged, so there is no reason to publish a new release.
+
+Why it matters: a new tag signals to every consumer that the binary changed. CI, documentation, or test churn must never inflate the version.
+
+Two important details:
+
+- Release Please classifies commits by **type only; the scope is ignored**. `fix(ci): ...` is still a `fix` and produces a patch release. Never use `feat` or `fix` for infrastructure-only changes — use the matching non-releasing type with a scope instead, for example `ci(release): ...`.
+- Prefer `fix` over `feat` for corrections: `feat` is for new user-facing capability only; making previously incorrect behavior correct is a `fix`.
+
+Examples:
+
+- Adjust a GitHub Actions workflow -> `ci: ...` (no release).
+- Add a new masking algorithm -> `feat: ...` (minor).
+- Fix incorrect masking of emails with plus signs -> `fix: ...` (patch).
+- Reword the README -> `docs: ...` (no release).
+- Add benchmarks only -> `test: ...` (no release); if the same change also adds a binary feature such as a CPU profiling flag, it is a `feat`.
 
 ## What Developers Must Write
 


### PR DESCRIPTION
## Summary

Codifies a strict rule for when a release may be cut: only changes that alter the shipped `maskdump` binary warrant a version bump.

- `docs/releasing.md`: new section "Version Discipline: What Warrants a Release" — binary-affecting changes (`*.go` except tests, `go.mod`, `go.sum`) use `feat:`/`fix:`/`perf:` and cut a release; CI, docs, tests, tooling and example configs use `ci:`/`docs:`/`test:`/`build:`/`chore:` and never trigger one.
- `AGENTS.md`: the same rule in short form under "Release and Commit Conventions", plus an explicit warning that Release Please classifies commits by type only and ignores the scope — `fix(ci): ...` still produces a patch release.
- `AGENTS.md`: PR creation guidance — prefer `gh pr create` with an explicit Conventional Commit title instead of branch-name-derived defaults.

## Motivation

The pending 0.4.0 release PR was partly driven by `fix(ci)`/`fix(test)`/`fix(release)` commits — infrastructure changes mistyped as `fix`. The previous wording in the docs was only advisory; this makes the boundary explicit. Mirrors the established practice in pinba_engine.

Docs-only change: does not trigger a release itself.