### PR TITLE
feat(dialect): support table filtering across sql dump dialects

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ mysqldump dbname | ./maskdump --mask-email=light-hash --mask-phone=light-mask > 
 | `--no-cache`     | Disable caching of masked values                 | false        |
 | `--config`       | Path to configuration file                      | (autodetect) |
 | `--cpu-profile`  | Write CPU profile for profiling runs            | (disabled)   |
+| `--db-format`    | Dump dialect: `auto`, `mysql`, `postgresql`, `oracle`, `mssql`, `sqlite`, `firebird` | `auto` |
+
+With `--db-format=auto` (the default) the dialect is detected from the dump content. Explicitly setting the format is recommended for production pipelines: the flag overrides the `db_format` config field. Table skipping (`skip_insert_into_table_list`) and selective field masking (`processing_tables`) work for all listed dialects, including PostgreSQL `COPY ... FROM stdin` blocks. Table names in the config may be plain (`tst_users`) or schema-qualified (`public.tst_users`). If the dialect cannot be detected, maskdump falls back to full-line regex masking and logs a warning; selective filtering is disabled in that mode.
 
 ### Configuration file
 
@@ -93,6 +96,7 @@ Create `maskdump.conf` in the same directory as the binary or specify path with 
 
 ```json
 {
+  "db_format": "auto",
   "cache_path": "/home/user/.cache/maskdump/cache.json",
   "email_regex": "\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\\b",
   "phone_regex": "(?:\\+7|7|8)?(?:[\\s\\-\\(\\)]*\\d){10}",
@@ -282,6 +286,9 @@ mysqldump dbname | ./maskdump --mask-email=light-hash --mask-phone=light-mask > 
 | `--no-cache`    | Отключить кэширование                        | false        |
 | `--config`      | Путь к конфигурационному файлу               | (автопоиск) |
 | `--cpu-profile` | Записать CPU profile для профилирования      | (отключено)  |
+| `--db-format`   | Диалект дампа: `auto`, `mysql`, `postgresql`, `oracle`, `mssql`, `sqlite`, `firebird` | `auto` |
+
+При `--db-format=auto` (по умолчанию) диалект определяется по содержимому дампа. Для production-пайплайнов рекомендуется указывать формат явно: флаг имеет приоритет над полем `db_format` конфига. Пропуск таблиц (`skip_insert_into_table_list`) и выборочная маскировка полей (`processing_tables`) работают для всех перечисленных диалектов, включая блоки PostgreSQL `COPY ... FROM stdin`. Имена таблиц в конфиге могут быть простыми (`tst_users`) или со схемой (`public.tst_users`). Если диалект определить не удалось, maskdump переходит к полнострочной regex-маскировке с предупреждением в логе; выборочная фильтрация в этом режиме отключается.
 
 ### Конфигурационный файл
 
@@ -289,6 +296,7 @@ mysqldump dbname | ./maskdump --mask-email=light-hash --mask-phone=light-mask > 
 
 ```json
 {
+  "db_format": "auto",
   "cache_path": "/home/user/.cache/maskdump/cache.json",
   "email_regex": "\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\\b",
   "phone_regex": "(?:\\+7|7|8)?(?:[\\s\\-\\(\\)]*\\d){10}",

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -82,10 +82,10 @@ func BenchmarkProcessLine(b *testing.B) {
 	)
 	config := MaskConfig{emailAlgorithm: "light-hash", phoneAlgorithm: "light-mask"}
 	runtimeState := NewRuntimeFromGlobals()
-	parser := NewTableParser(runtimeState)
+	parser := NewDialectParser(DialectMySQL, runtimeState)
 
 	b.ResetTimer()
 	for b.Loop() {
-		_ = processLine(line, config, nil, runtimeState, parser, false)
+		_, _ = processLine(line, config, nil, parser)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ type TableConfig struct {
 
 // Config holds the full application configuration.
 type Config struct {
+	DBFormat                string                 `json:"db_format"`
 	CachePath               string                 `json:"cache_path"`
 	EmailRegex              string                 `json:"email_regex"`
 	PhoneRegex              string                 `json:"phone_regex"`
@@ -150,6 +151,7 @@ func LoadSkipList(path string) (map[string]struct{}, error) {
 func LoadConfig(explicitPath string) error {
 	// 1. Set default values first
 	defaultConfig := Config{
+		DBFormat:                string(DialectAuto),
 		CachePath:               filepath.Join(os.Getenv("HOME"), defaultCacheFileName),
 		EmailRegex:              defaultEmailRegex,
 		PhoneRegex:              defaultPhoneRegex,
@@ -207,6 +209,9 @@ func LoadConfig(explicitPath string) error {
 		}
 
 		// Override default values with non-empty values from config file
+		if fileConfig.DBFormat != "" {
+			AppConfig.DBFormat = fileConfig.DBFormat
+		}
 		if fileConfig.CachePath != "" {
 			AppConfig.CachePath = fileConfig.CachePath
 		}
@@ -266,6 +271,13 @@ func LoadConfig(explicitPath string) error {
 }
 
 func validateConfig() error {
+	// Validate the dump dialect selector
+	dialect, dialectErr := ParseDumpDialect(AppConfig.DBFormat)
+	if dialectErr != nil {
+		return dialectErr
+	}
+	AppConfig.DBFormat = string(dialect)
+
 	// For the cache, we check the directory's availability and write permissions
 	cacheDir := filepath.Dir(AppConfig.CachePath)
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {

--- a/dialect.go
+++ b/dialect.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DumpDialect identifies the SQL dump format being processed.
+type DumpDialect string
+
+const (
+	// DialectAuto selects the dialect by content-based detection.
+	DialectAuto DumpDialect = "auto"
+	// DialectMySQL handles MySQL / MariaDB dumps.
+	DialectMySQL DumpDialect = "mysql"
+	// DialectPostgreSQL handles PostgreSQL dumps (COPY and INSERT styles).
+	DialectPostgreSQL DumpDialect = "postgresql"
+	// DialectOracle handles Oracle dumps.
+	DialectOracle DumpDialect = "oracle"
+	// DialectMSSQL handles MS SQL Server dumps.
+	DialectMSSQL DumpDialect = "mssql"
+	// DialectSQLite handles SQLite dumps.
+	DialectSQLite DumpDialect = "sqlite"
+	// DialectFirebird handles Firebird dumps.
+	DialectFirebird DumpDialect = "firebird"
+	// DialectGeneric is the internal fallback when no dialect-specific
+	// parsing is available: full-line regex masking only.
+	DialectGeneric DumpDialect = "generic"
+)
+
+// ParseDumpDialect validates a user-supplied db-format value.
+func ParseDumpDialect(value string) (DumpDialect, error) {
+	switch DumpDialect(strings.ToLower(strings.TrimSpace(value))) {
+	case "", DialectAuto:
+		return DialectAuto, nil
+	case DialectMySQL:
+		return DialectMySQL, nil
+	case DialectPostgreSQL:
+		return DialectPostgreSQL, nil
+	case DialectOracle:
+		return DialectOracle, nil
+	case DialectMSSQL:
+		return DialectMSSQL, nil
+	case DialectSQLite:
+		return DialectSQLite, nil
+	case DialectFirebird:
+		return DialectFirebird, nil
+	default:
+		return "", fmt.Errorf("unsupported db-format %q (expected auto|mysql|postgresql|oracle|mssql|sqlite|firebird)", value)
+	}
+}
+
+// DialectParser processes dump lines for one SQL dialect.
+//
+// ProcessLine receives one input line (with its trailing newline when
+// present) and returns the transformed output plus a drop flag. When drop is
+// true the line is removed from the output entirely. The returned string may
+// contain several lines when the parser flushes buffered input.
+type DialectParser interface {
+	Dialect() DumpDialect
+	ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool)
+}
+
+// NewDialectParser builds the parser implementation for the requested dialect.
+func NewDialectParser(dialect DumpDialect, rt *Runtime) DialectParser {
+	switch dialect {
+	case DialectMySQL:
+		return newMySQLDialectParser(rt)
+	case DialectPostgreSQL:
+		return newPostgresDialectParser(rt)
+	case DialectOracle:
+		return newSQLInsertDialectParser(rt, DialectOracle)
+	case DialectMSSQL:
+		return newSQLInsertDialectParser(rt, DialectMSSQL)
+	case DialectSQLite:
+		return newSQLInsertDialectParser(rt, DialectSQLite)
+	case DialectFirebird:
+		return newSQLInsertDialectParser(rt, DialectFirebird)
+	case DialectAuto:
+		return newDetectingDialectParser(rt)
+	default:
+		return newGenericDialectParser(rt)
+	}
+}
+
+// genericDialectParser is the safe fallback: it never skips lines and never
+// guesses field positions; it only applies full-line regex masking, matching
+// the historical behavior for dumps without table awareness.
+type genericDialectParser struct {
+	rt     *Runtime
+	warned bool
+}
+
+func newGenericDialectParser(rt *Runtime) *genericDialectParser {
+	return &genericDialectParser{rt: rt}
+}
+
+// Dialect implements DialectParser.
+func (p *genericDialectParser) Dialect() DumpDialect { return DialectGeneric }
+
+// ProcessLine implements DialectParser.
+func (p *genericDialectParser) ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool) {
+	if !p.warned {
+		p.warned = true
+		if (len(p.rt.SkipTableList) > 0 || len(p.rt.ProcessingTables) > 0) && logger != nil {
+			logger.Warn("selective table filtering is disabled: dump dialect is unknown, applying full-line masking only")
+		}
+	}
+	return maskFullLine(p.rt, line, config, cache), false
+}
+
+// maskFullLine applies the configured regex masking to a whole line without
+// any table or field awareness.
+func maskFullLine(rt *Runtime, line string, config MaskConfig, cache *Cache) string {
+	if config.emailAlgorithm == "light-hash" && rt.EmailRegex != nil {
+		line = rt.EmailRegex.ReplaceAllStringFunc(line, func(email string) string {
+			return rt.MaskEmailWithRules(email, cache)
+		})
+	}
+	if config.phoneAlgorithm == "light-mask" && rt.PhoneRegex != nil {
+		line = rt.PhoneRegex.ReplaceAllStringFunc(line, func(phone string) string {
+			return rt.MaskPhoneWithRules(phone, cache)
+		})
+	}
+	return line
+}
+
+// normalizeIdentifier strips dialect quoting from one SQL identifier:
+// `name` (MySQL), "name" (standard), [name] (MSSQL) and surrounding spaces.
+func normalizeIdentifier(raw string) string {
+	s := strings.TrimSpace(raw)
+	for len(s) >= 2 {
+		first := s[0]
+		last := s[len(s)-1]
+		if (first == '`' && last == '`') ||
+			(first == '"' && last == '"') ||
+			(first == '[' && last == ']') {
+			s = s[1 : len(s)-1]
+			continue
+		}
+		break
+	}
+	return s
+}
+
+// normalizeTableName strips quoting from a possibly schema-qualified table
+// reference and returns the normalized full name plus the plain table name
+// without the schema prefix ("public.users" -> "public.users", "users").
+func normalizeTableName(raw string) (full string, plain string) {
+	parts := strings.Split(strings.TrimSpace(raw), ".")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		normalized = append(normalized, normalizeIdentifier(part))
+	}
+	full = strings.Join(normalized, ".")
+	plain = normalized[len(normalized)-1]
+	return full, plain
+}
+
+// tableNameCandidates returns config lookup keys for a table reference:
+// the schema-qualified form first, then the plain name.
+func tableNameCandidates(raw string) []string {
+	full, plain := normalizeTableName(raw)
+	if full == plain {
+		return []string{plain}
+	}
+	return []string{full, plain}
+}
+
+// lookupProcessingTable finds the masking config for a table reference,
+// accepting both schema-qualified and plain config keys.
+func lookupProcessingTable(rt *Runtime, rawTable string) (TableConfig, bool) {
+	for _, name := range tableNameCandidates(rawTable) {
+		if cfg, ok := rt.ProcessingTables[name]; ok {
+			return cfg, true
+		}
+	}
+	return TableConfig{}, false
+}
+
+// isSkippedTable reports whether a table reference is in the skip list,
+// accepting both schema-qualified and plain config keys.
+func isSkippedTable(rt *Runtime, rawTable string) bool {
+	for _, name := range tableNameCandidates(rawTable) {
+		if _, ok := rt.SkipTableList[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldPositions resolves configured email/phone column names to 0-based
+// positions using an ordered column list. Unknown names are ignored.
+func fieldPositions(tableConfig TableConfig, columns []string, config MaskConfig) (emailPos, phonePos map[int]bool) {
+	emailPos = make(map[int]bool)
+	phonePos = make(map[int]bool)
+
+	index := make(map[string]int, len(columns))
+	for i, col := range columns {
+		index[normalizeIdentifier(col)] = i
+	}
+
+	if config.emailAlgorithm == "light-hash" {
+		for _, name := range tableConfig.Email {
+			if i, ok := index[name]; ok {
+				emailPos[i] = true
+			}
+		}
+	}
+	if config.phoneAlgorithm == "light-mask" {
+		for _, name := range tableConfig.Phone {
+			if i, ok := index[name]; ok {
+				phonePos[i] = true
+			}
+		}
+	}
+	return emailPos, phonePos
+}
+
+// maskValueAt applies email/phone masking to a single raw SQL value by its
+// column position. It returns the possibly modified value.
+func maskValueAt(rt *Runtime, value string, pos int, emailPos, phonePos map[int]bool, cache *Cache) string {
+	if value == "" || value == "NULL" {
+		return value
+	}
+	if emailPos[pos] && rt.EmailRegex != nil {
+		value = rt.EmailRegex.ReplaceAllStringFunc(value, func(email string) string {
+			return rt.MaskEmailWithRules(email, cache)
+		})
+	}
+	if phonePos[pos] && rt.PhoneRegex != nil {
+		value = rt.PhoneRegex.ReplaceAllStringFunc(value, func(phone string) string {
+			return rt.MaskPhoneWithRules(phone, cache)
+		})
+	}
+	return value
+}
+
+// maskTuples masks configured columns inside every (...) tuple found in s.
+func maskTuples(rt *Runtime, s string, emailPos, phonePos map[int]bool, cache *Cache) string {
+	if len(emailPos) == 0 && len(phonePos) == 0 {
+		return s
+	}
+	return tupleRegex.ReplaceAllStringFunc(s, func(tuple string) string {
+		values := parseTuple(tuple)
+		if len(values) == 0 {
+			return tuple
+		}
+		modified := false
+		for pos := range values {
+			masked := maskValueAt(rt, values[pos], pos, emailPos, phonePos, cache)
+			if masked != values[pos] {
+				values[pos] = masked
+				modified = true
+			}
+		}
+		if !modified {
+			return tuple
+		}
+		return "(" + strings.Join(values, ",") + ")"
+	})
+}

--- a/dialect_detect.go
+++ b/dialect_detect.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// detectMaxBufferedLines bounds how much input the auto-detector may buffer
+// before giving up and falling back, keeping the pipeline streaming-friendly.
+const detectMaxBufferedLines = 500
+
+// Decisive single-line markers per dialect. The first match wins.
+var dialectMarkers = []struct {
+	dialect DumpDialect
+	pattern *regexp.Regexp
+}{
+	{DialectMySQL, regexp.MustCompile(`^-- MySQL dump|^/\*!\d{5}|INSERT INTO ` + "`" + `|CREATE TABLE ` + "`")},
+	{DialectPostgreSQL, regexp.MustCompile(`^-- PostgreSQL database dump|FROM stdin;\s*$|^SET statement_timeout|^SELECT pg_catalog\.|^\\connect\s`)},
+	{DialectMSSQL, regexp.MustCompile(`^USE \[|^SET ANSI_NULLS|IDENTITY_INSERT|\[dbo\]\.`)},
+	{DialectSQLite, regexp.MustCompile(`^PRAGMA foreign_keys\s*=|sqlite_sequence|^-- SQLite dump`)},
+	{DialectOracle, regexp.MustCompile(`^-- Oracle Database dump|^SET DEFINE OFF|EXECUTE IMMEDIATE|VARCHAR2\(`)},
+	{DialectFirebird, regexp.MustCompile(`^SET TERM\s|RDB\$|^-- Firebird`)},
+}
+
+// detectingDialectParser implements --db-format=auto: it buffers input lines
+// until a decisive dialect marker appears, then replays the buffer through
+// the selected parser and delegates the rest of the stream to it.
+type detectingDialectParser struct {
+	rt       *Runtime
+	buffer   []string
+	delegate DialectParser
+}
+
+func newDetectingDialectParser(rt *Runtime) *detectingDialectParser {
+	return &detectingDialectParser{rt: rt}
+}
+
+// Dialect implements DialectParser.
+func (p *detectingDialectParser) Dialect() DumpDialect {
+	if p.delegate != nil {
+		return p.delegate.Dialect()
+	}
+	return DialectAuto
+}
+
+// ProcessLine implements DialectParser.
+func (p *detectingDialectParser) ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool) {
+	if p.delegate != nil {
+		return p.delegate.ProcessLine(line, config, cache)
+	}
+
+	dialect, ok := detectDialectLine(line)
+	if !ok {
+		p.buffer = append(p.buffer, line)
+		if len(p.buffer) < detectMaxBufferedLines {
+			return "", true // buffered, emitted later on flush
+		}
+		// No decisive marker within the buffer window: degrade safely to
+		// generic full-line masking.
+		if logger != nil {
+			logger.Warn("could not detect dump dialect within %d lines: falling back to generic masking", detectMaxBufferedLines)
+		}
+		p.selectDialect(DialectGeneric)
+		return p.flushBuffer(config, cache)
+	}
+	p.selectDialect(dialect)
+
+	if logger != nil {
+		logger.Info("detected dump dialect: %s", p.delegate.Dialect())
+	}
+	out, drop := p.flushBuffer(config, cache)
+	tail, tailDrop := p.delegate.ProcessLine(line, config, cache)
+	if tailDrop {
+		if out == "" {
+			return "", drop
+		}
+		return out, false
+	}
+	return out + tail, false
+}
+
+// Flush emits any input still buffered at end of stream through the generic
+// fallback (detection never became confident).
+func (p *detectingDialectParser) Flush(config MaskConfig, cache *Cache) string {
+	if p.delegate != nil || len(p.buffer) == 0 {
+		return ""
+	}
+	if logger != nil {
+		logger.Warn("could not detect dump dialect: falling back to generic masking")
+	}
+	p.selectDialect(DialectGeneric)
+	out, _ := p.flushBuffer(config, cache)
+	return out
+}
+
+func (p *detectingDialectParser) selectDialect(dialect DumpDialect) {
+	if dialect == DialectGeneric {
+		p.delegate = newGenericDialectParser(p.rt)
+		return
+	}
+	p.delegate = NewDialectParser(dialect, p.rt)
+}
+
+// flushBuffer replays buffered lines through the chosen delegate.
+func (p *detectingDialectParser) flushBuffer(config MaskConfig, cache *Cache) (string, bool) {
+	var out strings.Builder
+	dropped := true
+	for _, buffered := range p.buffer {
+		processed, drop := p.delegate.ProcessLine(buffered, config, cache)
+		if !drop {
+			out.WriteString(processed)
+			dropped = false
+		}
+	}
+	p.buffer = nil
+	if out.Len() == 0 {
+		return "", dropped
+	}
+	return out.String(), false
+}
+
+// detectDialectLine checks one line against the decisive dialect markers.
+func detectDialectLine(line string) (DumpDialect, bool) {
+	for _, marker := range dialectMarkers {
+		if marker.pattern.MatchString(line) {
+			return marker.dialect, true
+		}
+	}
+	return "", false
+}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -1,0 +1,40 @@
+package main
+
+import "strings"
+
+// mysqlDialectParser wraps the historical MySQL-specific processing:
+// backtick-quoted CREATE TABLE / INSERT parsing, skip list matching by
+// "INSERT INTO `table`" prefix and field-aware masking via TableParser.
+type mysqlDialectParser struct {
+	rt     *Runtime
+	tables *TableParser
+}
+
+func newMySQLDialectParser(rt *Runtime) *mysqlDialectParser {
+	return &mysqlDialectParser{
+		rt:     rt,
+		tables: NewTableParser(rt),
+	}
+}
+
+// Dialect implements DialectParser.
+func (p *mysqlDialectParser) Dialect() DumpDialect { return DialectMySQL }
+
+// ProcessLine implements DialectParser.
+func (p *mysqlDialectParser) ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool) {
+	if len(p.rt.SkipTableList) > 0 {
+		for table := range p.rt.SkipTableList {
+			if strings.HasPrefix(line, "INSERT INTO `"+table+"`") {
+				return "", true
+			}
+		}
+	}
+
+	if len(p.rt.ProcessingTables) > 0 {
+		p.tables.ParseTableStructure(line)
+		body, newline := splitTrailingNewline(line)
+		return p.tables.ProcessDumpLine(body, config, cache) + newline, false
+	}
+
+	return maskFullLine(p.rt, line, config, cache), false
+}

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// COPY "schema"."table" (col1, col2, ...) FROM stdin;
+var pgCopyRegex = regexp.MustCompile(`(?i)^COPY\s+([^\s(]+)\s*\(([^)]*)\)\s+FROM\s+stdin;\s*$`)
+
+const pgCopyTerminator = `\.`
+
+// postgresDialectParser handles pg_dump output in both COPY and INSERT
+// styles. INSERT statements and CREATE TABLE parsing are shared with the
+// generic SQL machinery; COPY blocks are handled here.
+type postgresDialectParser struct {
+	rt   *Runtime
+	proc *sqlStatementProcessor
+
+	// open COPY block state
+	copyActive bool
+	copyDrop   bool
+	copyEmail  map[int]bool
+	copyPhone  map[int]bool
+}
+
+func newPostgresDialectParser(rt *Runtime) *postgresDialectParser {
+	return &postgresDialectParser{
+		rt:   rt,
+		proc: newSQLStatementProcessor(rt),
+	}
+}
+
+// Dialect implements DialectParser.
+func (p *postgresDialectParser) Dialect() DumpDialect { return DialectPostgreSQL }
+
+// ProcessLine implements DialectParser.
+func (p *postgresDialectParser) ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool) {
+	selective := len(p.rt.ProcessingTables) > 0
+	filtering := selective || len(p.rt.SkipTableList) > 0
+	body, newline := splitTrailingNewline(line)
+
+	// Rows inside an open COPY block.
+	if p.copyActive {
+		if body == pgCopyTerminator {
+			drop := p.copyDrop
+			p.resetCopy()
+			return line, drop
+		}
+		if p.copyDrop {
+			return "", true
+		}
+		if len(p.copyEmail) == 0 && len(p.copyPhone) == 0 {
+			return line, false
+		}
+		return p.maskCopyRow(body, cache) + newline, false
+	}
+
+	if filtering {
+		if matches := pgCopyRegex.FindStringSubmatch(body); matches != nil {
+			return p.startCopyBlock(matches[1], matches[2], line, config)
+		}
+	}
+
+	if selective && !p.proc.insertActive && p.proc.processCreateTableLine(body) {
+		return line, false
+	}
+
+	if filtering {
+		out, drop, handled := p.proc.processInsertLine(body, config, cache)
+		if handled {
+			if drop {
+				return "", true
+			}
+			return out + newline, false
+		}
+	}
+
+	if selective {
+		// Selective mode masks only configured fields; unrelated lines
+		// pass through unchanged.
+		return line, false
+	}
+	return maskFullLine(p.rt, line, config, cache), false
+}
+
+// startCopyBlock opens a COPY ... FROM stdin block and decides how its rows
+// will be treated: dropped, masked by column position, or passed through.
+func (p *postgresDialectParser) startCopyBlock(table, columnList, line string, config MaskConfig) (string, bool) {
+	p.copyActive = true
+
+	if isSkippedTable(p.rt, table) {
+		p.copyDrop = true
+		return "", true
+	}
+
+	if tableConfig, ok := lookupProcessingTable(p.rt, table); ok {
+		columns := splitColumnList(columnList)
+		if len(columns) == 0 {
+			// Safety rule: no confident column positions, no masking.
+			if logger != nil {
+				logger.Warn("cannot parse COPY column list for table %s: rows pass through unmasked", table)
+			}
+		} else {
+			p.copyEmail, p.copyPhone = fieldPositions(tableConfig, columns, config)
+		}
+	}
+	return line, false
+}
+
+// maskCopyRow masks configured columns of one tab-separated COPY data row.
+// Literal tabs inside values are escaped as "\t" by pg_dump, so splitting on
+// the tab character is unambiguous. "\N" marks NULL and is left untouched.
+func (p *postgresDialectParser) maskCopyRow(body string, cache *Cache) string {
+	values := strings.Split(body, "\t")
+	for pos := range values {
+		if values[pos] == `\N` {
+			continue
+		}
+		values[pos] = maskValueAt(p.rt, values[pos], pos, p.copyEmail, p.copyPhone, cache)
+	}
+	return strings.Join(values, "\t")
+}
+
+func (p *postgresDialectParser) resetCopy() {
+	p.copyActive = false
+	p.copyDrop = false
+	p.copyEmail = nil
+	p.copyPhone = nil
+}

--- a/dialect_sql.go
+++ b/dialect_sql.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Shared statement-level parsing for dialects whose data lines are standard
+// SQL INSERT statements: PostgreSQL (--inserts), Oracle, MS SQL Server,
+// SQLite and Firebird. Identifiers may be bare, double-quoted or bracketed.
+var (
+	// INSERT INTO <table> [(col, ...)] VALUES <rest>
+	sqlInsertRegex = regexp.MustCompile(`(?i)^\s*INSERT\s+INTO\s+([` + "`" + `"\[\]\w$.]+)\s*(?:\(([^)]*)\)\s*)?VALUES\s*(.*)$`)
+	// CREATE TABLE [IF NOT EXISTS] <table> [(...]
+	sqlCreateTableRegex = regexp.MustCompile(`(?i)^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([` + "`" + `"\[\]\w$.]+)\s*(\(?)(.*)$`)
+	// A continuation line of a multi-row VALUES list: "(...)," or "(...);"
+	sqlTupleLineRegex = regexp.MustCompile(`^\s*\(.*\)\s*[,;]?\s*$`)
+	// First identifier of a column definition line inside CREATE TABLE.
+	sqlColumnDefRegex = regexp.MustCompile("^\\s*([`\"\\[]?)([\\w$]+)[`\"\\]]?\\s+")
+)
+
+// sqlConstraintKeywords are line starters inside CREATE TABLE that do not
+// declare a column.
+var sqlConstraintKeywords = map[string]struct{}{
+	"PRIMARY": {}, "UNIQUE": {}, "KEY": {}, "CONSTRAINT": {}, "FOREIGN": {},
+	"CHECK": {}, "INDEX": {}, "FULLTEXT": {}, "SPATIAL": {}, "EXCLUDE": {},
+	"LIKE": {}, "PERIOD": {},
+}
+
+// sqlStatementProcessor holds the streaming state shared by SQL-insert
+// dialects: collected table structures and the currently open multi-line
+// INSERT or CREATE TABLE statement.
+type sqlStatementProcessor struct {
+	rt *Runtime
+	// tables collects column order per table (normalized full and plain
+	// names both point at the same entry).
+	tables map[string][]string
+
+	// open CREATE TABLE statement state
+	creatingTable   string
+	creatingColumns []string
+
+	// open INSERT statement state
+	insertActive bool
+	insertDrop   bool
+	emailPos     map[int]bool
+	phonePos     map[int]bool
+}
+
+func newSQLStatementProcessor(rt *Runtime) *sqlStatementProcessor {
+	return &sqlStatementProcessor{
+		rt:     rt,
+		tables: make(map[string][]string),
+	}
+}
+
+// rememberTable stores the column order for both schema-qualified and plain
+// table names.
+func (p *sqlStatementProcessor) rememberTable(rawTable string, columns []string) {
+	if len(columns) == 0 {
+		return
+	}
+	full, plain := normalizeTableName(rawTable)
+	p.tables[full] = columns
+	p.tables[plain] = columns
+}
+
+// columnsFor returns the known column order for a table reference.
+func (p *sqlStatementProcessor) columnsFor(rawTable string) ([]string, bool) {
+	for _, name := range tableNameCandidates(rawTable) {
+		if cols, ok := p.tables[name]; ok {
+			return cols, true
+		}
+	}
+	return nil, false
+}
+
+// splitColumnList splits a "col1, col2, ..." list and normalizes identifiers.
+func splitColumnList(list string) []string {
+	parts := strings.Split(list, ",")
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := normalizeIdentifier(part)
+		if name == "" {
+			return nil
+		}
+		columns = append(columns, name)
+	}
+	return columns
+}
+
+// statementTerminated reports whether an INSERT VALUES fragment ends the
+// statement on this line.
+func statementTerminated(rest string) bool {
+	trimmed := strings.TrimRight(rest, " \t\r\n")
+	return strings.HasSuffix(trimmed, ";")
+}
+
+// processCreateTableLine consumes DDL lines. It returns true when the line
+// was part of a CREATE TABLE statement.
+func (p *sqlStatementProcessor) processCreateTableLine(line string) bool {
+	if p.creatingTable == "" {
+		matches := sqlCreateTableRegex.FindStringSubmatch(line)
+		if matches == nil {
+			return false
+		}
+		table := matches[1]
+		body := matches[3]
+		if matches[2] == "" && !strings.HasPrefix(strings.TrimSpace(body), "(") {
+			// CREATE TABLE without a column list on this line: the "("
+			// may follow on the next line; treat conservatively as a
+			// one-line statement we cannot use.
+			if !strings.Contains(body, "(") {
+				return true
+			}
+			body = body[strings.Index(body, "(")+1:]
+		}
+		// Single-line CREATE TABLE "t" (a int, b text);
+		if strings.Contains(body, ")") && strings.HasSuffix(strings.TrimRight(body, " \t\r\n"), ";") {
+			p.rememberTable(table, columnsFromDefinitionList(body[:strings.LastIndex(body, ")")]))
+			return true
+		}
+		p.creatingTable = table
+		p.creatingColumns = nil
+		if rest := strings.TrimSpace(body); rest != "" {
+			if col, ok := columnFromDefinitionLine(rest); ok {
+				p.creatingColumns = append(p.creatingColumns, col)
+			}
+		}
+		return true
+	}
+
+	// Inside an open CREATE TABLE block. A ")" line (with or without a
+	// trailing ";") closes the definition; MSSQL emits it without ";".
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, ")") || endTableRegex.MatchString(line) {
+		p.rememberTable(p.creatingTable, p.creatingColumns)
+		p.creatingTable = ""
+		p.creatingColumns = nil
+		return true
+	}
+	// An INSERT reaching this point means the CREATE TABLE block never
+	// closed as expected: abandon DDL state instead of consuming data.
+	if sqlInsertRegex.MatchString(trimmed) {
+		p.creatingTable = ""
+		p.creatingColumns = nil
+		return false
+	}
+	if col, ok := columnFromDefinitionLine(line); ok {
+		p.creatingColumns = append(p.creatingColumns, col)
+	}
+	return true
+}
+
+// columnsFromDefinitionList extracts column names from a single-line
+// "a int, b text, PRIMARY KEY (a)" definition body.
+func columnsFromDefinitionList(body string) []string {
+	var columns []string
+	depth := 0
+	start := 0
+	flush := func(end int) {
+		part := body[start:end]
+		if col, ok := columnFromDefinitionLine(part); ok {
+			columns = append(columns, col)
+		}
+	}
+	for i, c := range body {
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				flush(i)
+				start = i + 1
+			}
+		}
+	}
+	flush(len(body))
+	return columns
+}
+
+// columnFromDefinitionLine extracts the column name from one column
+// definition fragment, rejecting constraint clauses.
+func columnFromDefinitionLine(line string) (string, bool) {
+	matches := sqlColumnDefRegex.FindStringSubmatch(line)
+	if matches == nil {
+		return "", false
+	}
+	name := matches[2]
+	if matches[1] == "" {
+		if _, ok := sqlConstraintKeywords[strings.ToUpper(name)]; ok {
+			return "", false
+		}
+	}
+	return name, true
+}
+
+// processInsertLine handles INSERT statements, multi-line VALUES lists and
+// skip-listed tables. It returns the transformed line, a drop flag and
+// whether the line belonged to an INSERT statement.
+func (p *sqlStatementProcessor) processInsertLine(line string, config MaskConfig, cache *Cache) (string, bool, bool) {
+	// Continuation of an open multi-line VALUES list.
+	if p.insertActive {
+		if sqlTupleLineRegex.MatchString(line) {
+			drop := p.insertDrop
+			emailPos, phonePos := p.emailPos, p.phonePos
+			if statementTerminated(line) {
+				p.resetInsert()
+			}
+			if drop {
+				return "", true, true
+			}
+			if len(emailPos) == 0 && len(phonePos) == 0 {
+				return line, false, true
+			}
+			return maskTuples(p.rt, line, emailPos, phonePos, cache), false, true
+		}
+		// The line does not look like a tuple: the statement ended
+		// implicitly. Safety rule: never consume lines we are not sure
+		// about; fall through to regular processing.
+		p.resetInsert()
+	}
+
+	matches := sqlInsertRegex.FindStringSubmatch(line)
+	if matches == nil {
+		return line, false, false
+	}
+	table := matches[1]
+	columnList := matches[2]
+	rest := matches[3]
+
+	// Multi-line statements keep state until the closing ";".
+	multiLine := !statementTerminated(rest)
+
+	if isSkippedTable(p.rt, table) {
+		if multiLine {
+			p.insertActive = true
+			p.insertDrop = true
+		}
+		return "", true, true
+	}
+
+	tableConfig, ok := lookupProcessingTable(p.rt, table)
+	if !ok {
+		if multiLine && strings.TrimSpace(rest) == "" {
+			// Open multi-line VALUES list of an unconfigured table: keep
+			// passing tuple lines through untouched.
+			p.insertActive = true
+			p.insertDrop = false
+			p.emailPos = nil
+			p.phonePos = nil
+		}
+		return line, false, true
+	}
+
+	var columns []string
+	if strings.TrimSpace(columnList) != "" {
+		columns = splitColumnList(columnList)
+	} else {
+		columns, _ = p.columnsFor(table)
+	}
+	if len(columns) == 0 {
+		// Safety rule: without confident column positions no field-aware
+		// masking is applied.
+		if logger != nil {
+			logger.Warn("no column information for table %s: leaving INSERT unmasked", table)
+		}
+		return line, false, true
+	}
+
+	emailPos, phonePos := fieldPositions(tableConfig, columns, config)
+	if multiLine {
+		p.insertActive = true
+		p.insertDrop = false
+		p.emailPos = emailPos
+		p.phonePos = phonePos
+	}
+	if strings.TrimSpace(rest) == "" {
+		return line, false, true
+	}
+	masked := maskTuples(p.rt, rest, emailPos, phonePos, cache)
+	if masked == rest {
+		return line, false, true
+	}
+	return line[:len(line)-len(rest)] + masked, false, true
+}
+
+// resetInsert clears the multi-line INSERT statement state.
+func (p *sqlStatementProcessor) resetInsert() {
+	p.insertActive = false
+	p.insertDrop = false
+	p.emailPos = nil
+	p.phonePos = nil
+}
+
+// sqlInsertDialectParser adapts sqlStatementProcessor to the DialectParser
+// interface for Oracle, MSSQL, SQLite and Firebird dumps.
+type sqlInsertDialectParser struct {
+	dialect DumpDialect
+	rt      *Runtime
+	proc    *sqlStatementProcessor
+}
+
+func newSQLInsertDialectParser(rt *Runtime, dialect DumpDialect) *sqlInsertDialectParser {
+	return &sqlInsertDialectParser{
+		dialect: dialect,
+		rt:      rt,
+		proc:    newSQLStatementProcessor(rt),
+	}
+}
+
+// Dialect implements DialectParser.
+func (p *sqlInsertDialectParser) Dialect() DumpDialect { return p.dialect }
+
+// ProcessLine implements DialectParser.
+func (p *sqlInsertDialectParser) ProcessLine(line string, config MaskConfig, cache *Cache) (string, bool) {
+	selective := len(p.rt.ProcessingTables) > 0
+	body, newline := splitTrailingNewline(line)
+
+	if selective && !p.proc.insertActive && p.proc.processCreateTableLine(body) {
+		return line, false
+	}
+
+	if selective || len(p.rt.SkipTableList) > 0 {
+		out, drop, handled := p.proc.processInsertLine(body, config, cache)
+		if handled {
+			if drop {
+				return "", true
+			}
+			return out + newline, false
+		}
+	}
+
+	if selective {
+		// Selective mode masks only configured fields; unrelated lines
+		// pass through unchanged.
+		return line, false
+	}
+	return maskFullLine(p.rt, line, config, cache), false
+}
+
+// splitTrailingNewline separates the line body from its trailing newline so
+// anchored regexes can match the body. The newline is re-appended on output.
+func splitTrailingNewline(line string) (body, newline string) {
+	if strings.HasSuffix(line, "\r\n") {
+		return line[:len(line)-2], "\r\n"
+	}
+	if strings.HasSuffix(line, "\n") {
+		return line[:len(line)-1], "\n"
+	}
+	return line, ""
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,0 +1,464 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// processDump feeds a whole dump through a parser line by line, imitating
+// the main loop, and returns the produced output.
+func processDump(t *testing.T, parser DialectParser, config MaskConfig, input string) string {
+	t.Helper()
+
+	var out strings.Builder
+	for _, line := range strings.SplitAfter(input, "\n") {
+		if line == "" {
+			continue
+		}
+		res, drop := parser.ProcessLine(line, config, nil)
+		if !drop {
+			out.WriteString(res)
+		}
+	}
+	if fp, ok := parser.(flushableParser); ok {
+		out.WriteString(fp.Flush(config, nil))
+	}
+	return out.String()
+}
+
+func bothAlgorithms() MaskConfig {
+	return MaskConfig{emailAlgorithm: "light-hash", phoneAlgorithm: "light-mask"}
+}
+
+func TestParseDumpDialect(t *testing.T) {
+	for value, expected := range map[string]DumpDialect{
+		"":           DialectAuto,
+		"auto":       DialectAuto,
+		"MySQL":      DialectMySQL,
+		"postgresql": DialectPostgreSQL,
+		"oracle":     DialectOracle,
+		"mssql":      DialectMSSQL,
+		"sqlite":     DialectSQLite,
+		"firebird":   DialectFirebird,
+	} {
+		dialect, err := ParseDumpDialect(value)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", value, err)
+		}
+		if dialect != expected {
+			t.Fatalf("expected %s for %q, got %s", expected, value, dialect)
+		}
+	}
+
+	if _, err := ParseDumpDialect("dbase"); err == nil {
+		t.Fatal("expected error for unsupported dialect")
+	}
+}
+
+func TestNormalizeTableName(t *testing.T) {
+	cases := []struct {
+		raw   string
+		full  string
+		plain string
+	}{
+		{"users", "users", "users"},
+		{"`users`", "users", "users"},
+		{`"public"."tst_users"`, "public.tst_users", "tst_users"},
+		{"[dbo].[tst_users]", "dbo.tst_users", "tst_users"},
+		{`public.tst_users`, "public.tst_users", "tst_users"},
+	}
+	for _, tc := range cases {
+		full, plain := normalizeTableName(tc.raw)
+		if full != tc.full || plain != tc.plain {
+			t.Fatalf("%s: expected (%s, %s), got (%s, %s)", tc.raw, tc.full, tc.plain, full, plain)
+		}
+	}
+}
+
+func TestMySQLDialectSkipTable(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		SkipTableList = map[string]struct{}{"secrets": {}}
+
+		parser := NewDialectParser(DialectMySQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(),
+			"INSERT INTO `secrets` VALUES (1,'x@y.com');\n"+
+				"INSERT INTO `visible` VALUES (2,'keep');\n")
+
+		if strings.Contains(out, "secrets") {
+			t.Fatalf("expected skipped table to be dropped, got: %s", out)
+		}
+		if !strings.Contains(out, "visible") {
+			t.Fatalf("expected other tables to remain, got: %s", out)
+		}
+	})
+}
+
+// A single pass must mask configured fields exactly once even when both
+// masking algorithms are enabled (regression: the line was processed twice).
+func TestMySQLDialectSelectiveMasksOnce(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"users": {Email: []string{"email"}, Phone: []string{"phone"}},
+		}
+
+		dump := "CREATE TABLE `users` (\n" +
+			"  `id` int,\n" +
+			"  `email` varchar(255),\n" +
+			"  `phone` varchar(32)\n" +
+			");\n" +
+			"INSERT INTO `users` VALUES (1,'test@example.com','+7 (123) 456-78-90');\n"
+
+		parser := NewDialectParser(DialectMySQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		// md5("test")[:6] == 098f6b: a single masking application keeps
+		// the first character and replaces the tail once.
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected email masked exactly once, got: %s", out)
+		}
+		if !strings.HasSuffix(out, "\n") {
+			t.Fatalf("expected trailing newline to be preserved, got: %q", out)
+		}
+	})
+}
+
+func TestPostgresCopyMasking(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"public.tst_users": {Email: []string{"email"}, Phone: []string{"phone"}},
+		}
+
+		dump := `COPY public.tst_users (id, login, email, phone, extra) FROM stdin;` + "\n" +
+			"1\tignore@stay.com\ttest@example.com\t+7 (123) 456-78-90\t{\"note\": \"json stays\"}\n" +
+			"2\tlogin2\t\\N\t\\N\tvalue\twith\\ttab\n" +
+			`\.` + "\n" +
+			"SELECT 1;\n"
+
+		parser := NewDialectParser(DialectPostgreSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected configured email column masked, got: %s", out)
+		}
+		if !strings.Contains(out, "ignore@stay.com") {
+			t.Fatalf("expected unconfigured column untouched, got: %s", out)
+		}
+		if strings.Contains(out, "+7 (123) 456-78-90") {
+			t.Fatalf("expected configured phone column masked, got: %s", out)
+		}
+		if !strings.Contains(out, `\N`) {
+			t.Fatalf("expected NULL markers preserved, got: %s", out)
+		}
+		if !strings.Contains(out, `{"note": "json stays"}`) {
+			t.Fatalf("expected JSON value untouched, got: %s", out)
+		}
+		if !strings.Contains(out, `\.`+"\n") {
+			t.Fatalf("expected COPY terminator preserved, got: %s", out)
+		}
+		if !strings.Contains(out, "SELECT 1;") {
+			t.Fatalf("expected trailing statement preserved, got: %s", out)
+		}
+	})
+}
+
+func TestPostgresCopyMatchesPlainConfigKey(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"tst_users": {Email: []string{"email"}},
+		}
+
+		dump := `COPY "public"."tst_users" ("id", "email") FROM stdin;` + "\n" +
+			"1\ttest@example.com\n" +
+			`\.` + "\n"
+
+		parser := NewDialectParser(DialectPostgreSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected plain config key to match schema-qualified COPY, got: %s", out)
+		}
+	})
+}
+
+func TestPostgresCopySkipTable(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		SkipTableList = map[string]struct{}{"tst_secrets": {}}
+
+		dump := "COPY public.tst_secrets (id, token) FROM stdin;\n" +
+			"1\tsecret-token\n" +
+			`\.` + "\n" +
+			"COPY public.tst_keep (id) FROM stdin;\n" +
+			"7\n" +
+			`\.` + "\n"
+
+		parser := NewDialectParser(DialectPostgreSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if strings.Contains(out, "secret-token") || strings.Contains(out, "tst_secrets") {
+			t.Fatalf("expected skipped COPY block to be dropped entirely, got: %s", out)
+		}
+		if !strings.Contains(out, "tst_keep") || !strings.Contains(out, "7\n") {
+			t.Fatalf("expected following COPY block to remain, got: %s", out)
+		}
+	})
+}
+
+func TestPostgresMultiLineInsertMasking(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"tst_users": {Email: []string{"email"}},
+		}
+
+		dump := "INSERT INTO public.tst_users (id, login, email) VALUES\n" +
+			"(1, 'login-one', 'test@example.com'),\n" +
+			"(2, 'keep@untouched.com', 'test@example.com');\n" +
+			"INSERT INTO public.tst_other (id, email) VALUES\n" +
+			"(3, 'other@stays.com');\n"
+
+		parser := NewDialectParser(DialectPostgreSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if strings.Count(out, "t098f6b@example.com") != 2 {
+			t.Fatalf("expected email column masked in every row, got: %s", out)
+		}
+		if !strings.Contains(out, "keep@untouched.com") {
+			t.Fatalf("expected unconfigured column untouched, got: %s", out)
+		}
+		if !strings.Contains(out, "other@stays.com") {
+			t.Fatalf("expected unconfigured table untouched, got: %s", out)
+		}
+	})
+}
+
+func TestPostgresMultiLineInsertSkip(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		SkipTableList = map[string]struct{}{"tst_secrets": {}}
+
+		dump := "INSERT INTO public.tst_secrets (id, token) VALUES\n" +
+			"(1, 'secret-a'),\n" +
+			"(2, 'secret-b');\n" +
+			"SELECT 'after';\n"
+
+		parser := NewDialectParser(DialectPostgreSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if strings.Contains(out, "secret") {
+			t.Fatalf("expected skipped INSERT statement dropped, got: %s", out)
+		}
+		if !strings.Contains(out, "SELECT 'after';") {
+			t.Fatalf("expected the following line to remain, got: %s", out)
+		}
+	})
+}
+
+func TestOracleInsertMasking(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"tst_users": {Email: []string{"email"}, Phone: []string{"phone"}},
+		}
+
+		dump := "INSERT INTO tst_users (id, login, email, phone) VALUES (1, 'test@example.com', 'test@example.com', '+7 (123) 456-78-90');\n"
+
+		parser := NewDialectParser(DialectOracle, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if strings.Count(out, "t098f6b@example.com") != 1 {
+			t.Fatalf("expected only the configured email column masked, got: %s", out)
+		}
+		if !strings.Contains(out, "'test@example.com'") {
+			t.Fatalf("expected login column untouched, got: %s", out)
+		}
+		if strings.Contains(out, "+7 (123) 456-78-90") {
+			t.Fatalf("expected phone column masked, got: %s", out)
+		}
+	})
+}
+
+func TestMSSQLInsertMaskingAndSkip(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"tst_users": {Email: []string{"email"}},
+		}
+		SkipTableList = map[string]struct{}{"tst_secrets": {}}
+
+		dump := "SET ANSI_NULLS ON\n" +
+			"GO\n" +
+			"INSERT INTO [dbo].[tst_users] ([id], [email]) VALUES (1, N'test@example.com')\n" +
+			"INSERT INTO [dbo].[tst_secrets] ([id], [token]) VALUES (1, N'secret')\n" +
+			"GO\n"
+
+		parser := NewDialectParser(DialectMSSQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "N't098f6b@example.com'") {
+			t.Fatalf("expected email masked inside N'...' literal, got: %s", out)
+		}
+		if strings.Contains(out, "secret") {
+			t.Fatalf("expected skipped table INSERT dropped, got: %s", out)
+		}
+		if strings.Count(out, "GO\n") != 2 {
+			t.Fatalf("expected GO separators preserved, got: %s", out)
+		}
+	})
+}
+
+func TestSQLiteInsertWithoutColumnList(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"users": {Email: []string{"email"}},
+		}
+
+		dump := "PRAGMA foreign_keys=OFF;\n" +
+			"CREATE TABLE \"users\" (id INTEGER PRIMARY KEY, email TEXT, note TEXT);\n" +
+			"INSERT INTO \"users\" VALUES(1,'test@example.com','note keep@here.com');\n"
+
+		parser := NewDialectParser(DialectSQLite, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected email masked via CREATE TABLE positions, got: %s", out)
+		}
+		if !strings.Contains(out, "keep@here.com") {
+			t.Fatalf("expected unconfigured column untouched, got: %s", out)
+		}
+	})
+}
+
+func TestFirebirdInsertMasking(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"USERS": {Email: []string{"EMAIL"}},
+		}
+
+		dump := "SET TERM ^ ;\n" +
+			"INSERT INTO \"USERS\" (\"ID\", \"EMAIL\") VALUES (1, 'test@example.com');\n"
+
+		parser := NewDialectParser(DialectFirebird, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected email masked, got: %s", out)
+		}
+		if !strings.Contains(out, "SET TERM ^ ;") {
+			t.Fatalf("expected SET TERM line preserved, got: %s", out)
+		}
+	})
+}
+
+func TestSelectiveModeWithoutColumnInfoLeavesLineUntouched(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		ProcessingTables = map[string]TableConfig{
+			"users": {Email: []string{"email"}},
+		}
+
+		// No CREATE TABLE seen and no column list in the INSERT: the safe
+		// behavior is to pass the line through unmasked.
+		dump := "INSERT INTO users VALUES (1,'test@example.com');\n"
+
+		parser := NewDialectParser(DialectOracle, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if out != dump {
+			t.Fatalf("expected line unchanged without column info, got: %s", out)
+		}
+	})
+}
+
+func TestDialectAutoDetection(t *testing.T) {
+	cases := []struct {
+		name      string
+		firstLine string
+		expected  DumpDialect
+	}{
+		{"mysql", "-- MySQL dump 10.13  Distrib 8.0.36\n", DialectMySQL},
+		{"postgresql", "-- PostgreSQL database dump\n", DialectPostgreSQL},
+		{"oracle", "-- Oracle Database dump\n", DialectOracle},
+		{"mssql", "USE [maskdump]\n", DialectMSSQL},
+		{"sqlite", "PRAGMA foreign_keys=OFF;\n", DialectSQLite},
+		{"firebird", "SET TERM ^ ;\n", DialectFirebird},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTestGlobals(t, func() {
+				setupMaskingDefaults(t)
+				parser := NewDialectParser(DialectAuto, newTestRuntime())
+				out := processDump(t, parser, bothAlgorithms(), tc.firstLine)
+
+				if parser.Dialect() != tc.expected {
+					t.Fatalf("expected %s, got %s", tc.expected, parser.Dialect())
+				}
+				if out != tc.firstLine {
+					t.Fatalf("expected marker line passed through, got: %q", out)
+				}
+			})
+		})
+	}
+}
+
+func TestDialectAutoDetectionBuffersAndReplays(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+		SkipTableList = map[string]struct{}{"secrets": {}}
+
+		dump := "-- comment first\n" +
+			"-- PostgreSQL database dump\n" +
+			"COPY secrets (id) FROM stdin;\n" +
+			"1\n" +
+			`\.` + "\n"
+
+		parser := NewDialectParser(DialectAuto, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "-- comment first") {
+			t.Fatalf("expected buffered pre-marker line replayed, got: %q", out)
+		}
+		if strings.Contains(out, "secrets") {
+			t.Fatalf("expected skip list applied after detection, got: %q", out)
+		}
+	})
+}
+
+func TestDialectAutoDetectionFallbackFlush(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+
+		dump := "no markers here test@example.com\n" +
+			"just plain text\n"
+
+		parser := NewDialectParser(DialectAuto, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), dump)
+
+		if !strings.Contains(out, "t098f6b@example.com") {
+			t.Fatalf("expected generic masking applied on flush, got: %q", out)
+		}
+		if !strings.Contains(out, "just plain text") {
+			t.Fatalf("expected all buffered lines flushed, got: %q", out)
+		}
+	})
+}
+
+func TestBlankLinesArePreserved(t *testing.T) {
+	withTestGlobals(t, func() {
+		setupMaskingDefaults(t)
+
+		parser := NewDialectParser(DialectMySQL, newTestRuntime())
+		out := processDump(t, parser, bothAlgorithms(), "line one\n\nline two\n")
+
+		if out != "line one\n\nline two\n" {
+			t.Fatalf("expected blank line preserved, got: %q", out)
+		}
+	})
+}

--- a/maskdump.conf.example
+++ b/maskdump.conf.example
@@ -1,4 +1,5 @@
 {
+  "db_format": "auto",
   "cache_path": "/path/to/custom_cache.json",
   "email_regex": "\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\\b",
   "phone_regex": "\\b(?:\\+7|7|8)(?:[\\s-]?\\(?\\d{3}\\)?[\\s-]?\\d{3}[\\s-]?\\d{2}[\\s-]?\\d{2}|\\d{10})\\b",

--- a/maskdump.go
+++ b/maskdump.go
@@ -39,6 +39,7 @@ type MaskConfig struct {
 	cacheEnabled   bool
 	configFile     string
 	cpuProfilePath string
+	dbFormat       string
 }
 
 // LogConfig configures file logging.
@@ -272,6 +273,7 @@ func parseFlags() MaskConfig {
 	noCache := flag.Bool("no-cache", false, "Disable caching")
 	configFile := flag.String("config", "", "Path to config file")
 	cpuProfile := flag.String("cpu-profile", "", "Write CPU profile to the specified file")
+	dbFormat := flag.String("db-format", "", "Dump dialect: auto|mysql|postgresql|oracle|mssql|sqlite|firebird (default: config db_format or auto)")
 
 	flag.Parse()
 
@@ -281,6 +283,7 @@ func parseFlags() MaskConfig {
 		cacheEnabled:   !*noCache,
 		configFile:     *configFile,
 		cpuProfilePath: *cpuProfile,
+		dbFormat:       *dbFormat,
 	}
 }
 
@@ -587,42 +590,25 @@ func replacePositions(value string, positions []int, hash string) string {
 	return string(final)
 }
 
-// It's a basic function. It processes incoming strings.
-// It starts the necessary masking functions according to the program settings.
-func processLine(line string, config MaskConfig, cache *Cache, runtime *Runtime, parser *TableParser, hasProcessingTables bool) string {
-	if len(runtime.SkipTableList) > 0 {
-		for table := range runtime.SkipTableList {
-			if strings.HasPrefix(line, "INSERT INTO `"+table+"`") {
-				return ""
-			}
-		}
+// resolveDialect picks the effective dump dialect: the CLI flag wins over
+// the config file, which defaults to auto-detection.
+func resolveDialect(config MaskConfig) (DumpDialect, error) {
+	if config.dbFormat != "" {
+		return ParseDumpDialect(config.dbFormat)
 	}
+	return ParseDumpDialect(AppConfig.DBFormat)
+}
 
-	if hasProcessingTables {
-		parser.ParseTableStructure(line)
-	}
+// flushableParser is implemented by parsers that may hold buffered input at
+// end of stream (auto-detection).
+type flushableParser interface {
+	Flush(config MaskConfig, cache *Cache) string
+}
 
-	if config.emailAlgorithm == "light-hash" {
-		if hasProcessingTables {
-			line = parser.ProcessDumpLine(line, config, cache)
-		} else if runtime.EmailRegex != nil {
-			line = runtime.EmailRegex.ReplaceAllStringFunc(line, func(email string) string {
-				return runtime.MaskEmailWithRules(email, cache)
-			})
-		}
-	}
-
-	if config.phoneAlgorithm == "light-mask" {
-		if hasProcessingTables {
-			line = parser.ProcessDumpLine(line, config, cache)
-		} else if runtime.PhoneRegex != nil {
-			line = runtime.PhoneRegex.ReplaceAllStringFunc(line, func(phone string) string {
-				return runtime.MaskPhoneWithRules(phone, cache)
-			})
-		}
-	}
-
-	return line
+// processLine routes one input line through the dialect parser. An empty
+// return with drop means the line is removed from the output.
+func processLine(line string, config MaskConfig, cache *Cache, parser DialectParser) (string, bool) {
+	return parser.ProcessLine(line, config, cache)
 }
 
 // The function prepares the required values of the setting variables.
@@ -722,7 +708,15 @@ func main() {
 	memoryLimit = int64(AppConfig.MemoryLimitMB) * 1024 * 1024
 	go trackMemoryUsage()
 	runtimeState := NewRuntimeFromGlobals()
-	parser := NewTableParser(runtimeState)
+
+	dialect, err := resolveDialect(config)
+	if err != nil {
+		logger.Error("Invalid db-format: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	parser := NewDialectParser(dialect, runtimeState)
+	logger.Info("Using dump dialect: %s", dialect)
 
 	reader := bufio.NewReaderSize(os.Stdin, defaultMaxBufferSize)
 	writer := bufio.NewWriterSize(os.Stdout, defaultMaxBufferSize)
@@ -732,22 +726,20 @@ func main() {
 		}
 	}()
 
-	// Checking if there are any processing tables
-	hasProcessingTables := len(runtimeState.ProcessingTables) > 0
-
 	lineCount := 0
 	for {
 		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
+		if err != nil && err != io.EOF {
 			logger.Error("Error reading input: %v", err)
 			os.Exit(1)
 		}
+		atEOF := err == io.EOF
+		if atEOF && line == "" {
+			break
+		}
 
-		maskedLine := processLine(line, config, cache, runtimeState, parser, hasProcessingTables)
-		if strings.TrimSpace(maskedLine) != "" {
+		maskedLine, drop := processLine(line, config, cache, parser)
+		if !drop {
 			_, err = writer.WriteString(maskedLine)
 			if err != nil {
 				logger.Error("Error writing output: %v", err)
@@ -759,6 +751,20 @@ func main() {
 		if lineCount%AppConfig.CacheFlushCount == 0 {
 			if checkMemoryLimit() {
 				freeMemory(cache)
+			}
+		}
+
+		if atEOF {
+			break
+		}
+	}
+
+	// Auto-detection may still hold buffered lines at end of stream.
+	if fp, ok := parser.(flushableParser); ok {
+		if tail := fp.Flush(config, cache); tail != "" {
+			if _, err := writer.WriteString(tail); err != nil {
+				logger.Error("Error writing output: %v", err)
+				os.Exit(1)
 			}
 		}
 	}

--- a/testdata/expected/dump/mssql/de_dump.sql
+++ b/testdata/expected/dump/mssql/de_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'max.weber', N'Max Weber', N'm6aaafc@t-online.de', N'017 980644', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'01664836507', N'Sophie Becker', N's3e7368@posteo.de', N'01664836507', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/fr_dump.sql
+++ b/testdata/expected/dump/mssql/fr_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'nicolas.moreau', N'Nicolas Moreau', N'n480f87@laposte.net', N'08 52 41 57 78', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'0761923442', N'Lea Petit', N'l2f18fa@proton.me', N'0761923442', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/gb_dump.sql
+++ b/testdata/expected/dump/mssql/gb_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'isla.wilson', N'Isla Wilson', N'i3f3a84@protonmail.com', N'0847 956 9153', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'03708516272', N'George Taylor', N'geb413f@yahoo.co.uk', N'03708516272', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/multi_dump.sql
+++ b/testdata/expected/dump/mssql/multi_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'00 32 38 50 01', N'Camille Bernard', N'c404c10@free.fr', N'00 32 38 50 01', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'ed763e6@telia.se', N'Erik Andersson', N'ed763e6@telia.se', N'+48 7 135 40 65', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/ru_dump.sql
+++ b/testdata/expected/dump/mssql/ru_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'o87cc5e@rambler.ru', N'Ольга Романова', N'o87cc5e@rambler.ru', N'+7 012 200 17 88', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'72962859031', N'Елена Соколова', N'e18ddbb@list.ru', N'72962859031', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/se_dump.sql
+++ b/testdata/expected/dump/mssql/se_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'oscar.lindberg', N'Oscar Lindberg', N'o8b7f6b@bahnhof.se', N'070-715 472', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'0911374868', N'Maja Karlsson', N'mf2f5a6@icloud.com', N'0911374868', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mssql/us_dump.sql
+++ b/testdata/expected/dump/mssql/us_dump.sql
@@ -4,6 +4,7 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[tst_groups](
     [id] bigint NOT NULL,
     [code] nvarchar(64) NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (1, N'admins', N'A
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (2, N'editors', N'Editorial Team')
 INSERT INTO [dbo].[tst_groups] ([id], [code], [title]) VALUES (3, N'support', N'Customer Success')
 GO
+
 CREATE TABLE [dbo].[tst_users](
     [id] bigint NOT NULL,
     [login] nvarchar(255) NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_i
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (4, N'olivia.wright', N'Olivia Wright', N'o1ca5a2@proton.me', N'+1 093 785 8184', 2)
 INSERT INTO [dbo].[tst_users] ([id], [login], [name], [email], [phone], [group_id]) VALUES (5, N'3465230742', N'Noah Davis', N'n989ba1@icloud.com', N'3465230742', 1)
 GO
+
 CREATE TABLE [dbo].[tst_posts](
     [id] bigint NOT NULL,
     [code] nvarchar(128) NOT NULL,

--- a/testdata/expected/dump/mysql/de_dump.sql
+++ b/testdata/expected/dump/mysql/de_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'l032979@mail.de','Leonie Fischer','l032979@mail.de','+43 (59) 2540 6389',3),
 (4,'max.weber','Max Weber','m6aaafc@t-online.de','017 980644',2),
 (5,'01664836507','Sophie Becker','s3e7368@posteo.de','01664836507',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/fr_dump.sql
+++ b/testdata/expected/dump/mysql/fr_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'jd1f176@sfr.fr','Julie Dubois','jd1f176@sfr.fr','+33 (0)4 99 01 04 00',3),
 (4,'nicolas.moreau','Nicolas Moreau','n480f87@laposte.net','08 52 41 57 78',2),
 (5,'0761923442','Lea Petit','l2f18fa@proton.me','0761923442',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/gb_dump.sql
+++ b/testdata/expected/dump/mysql/gb_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'h9d5504@gmail.com','Harry Jones','h9d5504@gmail.com','+42 662 998 0000',3),
 (4,'isla.wilson','Isla Wilson','i3f3a84@protonmail.com','0847 956 9153',2),
 (5,'03708516272','George Taylor','geb413f@yahoo.co.uk','03708516272',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/multi_dump.sql
+++ b/testdata/expected/dump/mysql/multi_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'lukas.schmidt','Lukas Schmidt','lba36a4@web.de','+45 50 2536 5878',3),
 (4,'00 32 38 50 01','Camille Bernard','c404c10@free.fr','00 32 38 50 01',2),
 (5,'ed763e6@telia.se','Erik Andersson','ed763e6@telia.se','+48 7 135 40 65',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/ru_dump.sql
+++ b/testdata/expected/dump/mysql/ru_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'sergey-volkov','Сергей Волков','s608e39@bk.ru','7 015 893 35 37',3),
 (4,'o87cc5e@rambler.ru','Ольга Романова','o87cc5e@rambler.ru','+7 012 200 17 88',2),
 (5,'72962859031','Елена Соколова','e18ddbb@list.ru','72962859031',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/se_dump.sql
+++ b/testdata/expected/dump/mysql/se_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'eaafd9e@gmail.com','Elsa Nilsson','eaafd9e@gmail.com','+46 (0)37-224 559',3),
 (4,'oscar.lindberg','Oscar Lindberg','o8b7f6b@bahnhof.se','070-715 472',2),
 (5,'0911374868','Maja Karlsson','mf2f5a6@icloud.com','0911374868',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/mysql/us_dump.sql
+++ b/testdata/expected/dump/mysql/us_dump.sql
@@ -4,6 +4,7 @@
 -- ------------------------------------------------------
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET NAMES utf8mb4 */;
+
 DROP TABLE IF EXISTS `tst_groups`;
 CREATE TABLE `tst_groups` (
   `id` bigint NOT NULL,
@@ -15,6 +16,7 @@ INSERT INTO `tst_groups` VALUES
 (1,'admins','Administrators'),
 (2,'editors','Editorial Team'),
 (3,'support','Customer Success');
+
 DROP TABLE IF EXISTS `tst_users`;
 CREATE TABLE `tst_users` (
   `id` bigint NOT NULL,
@@ -31,6 +33,7 @@ INSERT INTO `tst_users` VALUES
 (3,'me4e8d5@outlook.com','Mason Hall','me4e8d5@outlook.com','498-532-0536',3),
 (4,'olivia.wright','Olivia Wright','o1ca5a2@proton.me','+1 093 785 8184',2),
 (5,'3465230742','Noah Davis','n989ba1@icloud.com','3465230742',1);
+
 DROP TABLE IF EXISTS `tst_posts`;
 CREATE TABLE `tst_posts` (
   `id` bigint NOT NULL,

--- a/testdata/expected/dump/oracle/de_dump.sql
+++ b/testdata/expected/dump/oracle/de_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_DE
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '050 
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'l032979@mail.de', 'Leonie Fischer', 'l032979@mail.de', '+43 (59) 2540 6389', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'max.weber', 'Max Weber', 'm6aaafc@t-online.de', '017 980644', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '01664836507', 'Sophie Becker', 's3e7368@posteo.de', '01664836507', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/fr_dump.sql
+++ b/testdata/expected/dump/oracle/fr_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_FR
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '00 3
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'jd1f176@sfr.fr', 'Julie Dubois', 'jd1f176@sfr.fr', '+33 (0)4 99 01 04 00', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'nicolas.moreau', 'Nicolas Moreau', 'n480f87@laposte.net', '08 52 41 57 78', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '0761923442', 'Lea Petit', 'l2f18fa@proton.me', '0761923442', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/gb_dump.sql
+++ b/testdata/expected/dump/oracle/gb_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_GB
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '054 
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'h9d5504@gmail.com', 'Harry Jones', 'h9d5504@gmail.com', '+42 662 998 0000', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'isla.wilson', 'Isla Wilson', 'i3f3a84@protonmail.com', '0847 956 9153', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '03708516272', 'George Taylor', 'geb413f@yahoo.co.uk', '03708516272', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/multi_dump.sql
+++ b/testdata/expected/dump/oracle/multi_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_MULTI
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '(673
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'lukas.schmidt', 'Lukas Schmidt', 'lba36a4@web.de', '+45 50 2536 5878', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, '00 32 38 50 01', 'Camille Bernard', 'c404c10@free.fr', '00 32 38 50 01', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, 'ed763e6@telia.se', 'Erik Andersson', 'ed763e6@telia.se', '+48 7 135 40 65', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/ru_dump.sql
+++ b/testdata/expected/dump/oracle/ru_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_RU
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '8 21
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'sergey-volkov', 'Сергей Волков', 's608e39@bk.ru', '7 015 893 35 37', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'o87cc5e@rambler.ru', 'Ольга Романова', 'o87cc5e@rambler.ru', '+7 012 200 17 88', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '72962859031', 'Елена Соколова', 'e18ddbb@list.ru', '72962859031', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/se_dump.sql
+++ b/testdata/expected/dump/oracle/se_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_SE
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '09-9
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'eaafd9e@gmail.com', 'Elsa Nilsson', 'eaafd9e@gmail.com', '+46 (0)37-224 559', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'oscar.lindberg', 'Oscar Lindberg', 'o8b7f6b@bahnhof.se', '070-715 472', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '0911374868', 'Maja Karlsson', 'mf2f5a6@icloud.com', '0911374868', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/oracle/us_dump.sql
+++ b/testdata/expected/dump/oracle/us_dump.sql
@@ -1,12 +1,14 @@
 -- Oracle Database dump
 -- Schema: MASKDUMP_US
 SET DEFINE OFF;
+
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_groups'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_users'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
 BEGIN EXECUTE IMMEDIATE 'DROP TABLE tst_posts'; EXCEPTION WHEN OTHERS THEN NULL; END;
 /
+
 CREATE TABLE tst_groups (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(64 CHAR) NOT NULL,
@@ -15,6 +17,7 @@ CREATE TABLE tst_groups (
 INSERT INTO tst_groups (id, code, title) VALUES (1, 'admins', 'Administrators');
 INSERT INTO tst_groups (id, code, title) VALUES (2, 'editors', 'Editorial Team');
 INSERT INTO tst_groups (id, code, title) VALUES (3, 'support', 'Customer Success');
+
 CREATE TABLE tst_users (
     id NUMBER(19) PRIMARY KEY,
     login VARCHAR2(255 CHAR) NOT NULL,
@@ -28,6 +31,7 @@ INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (2, '(673
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (3, 'me4e8d5@outlook.com', 'Mason Hall', 'me4e8d5@outlook.com', '498-532-0536', 3);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (4, 'olivia.wright', 'Olivia Wright', 'o1ca5a2@proton.me', '+1 093 785 8184', 2);
 INSERT INTO tst_users (id, login, name, email, phone, group_id) VALUES (5, '3465230742', 'Noah Davis', 'n989ba1@icloud.com', '3465230742', 1);
+
 CREATE TABLE tst_posts (
     id NUMBER(19) PRIMARY KEY,
     code VARCHAR2(128 CHAR) NOT NULL,

--- a/testdata/expected/dump/postgresql/de_dump.sql
+++ b/testdata/expected/dump/postgresql/de_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'l032979@mail.de', 'Leonie Fischer', 'l032979@mail.de', '+43 (59) 2540 6389', 3),
 (4, 'max.weber', 'Max Weber', 'm6aaafc@t-online.de', '017 980644', 2),
 (5, '01664836507', 'Sophie Becker', 's3e7368@posteo.de', '01664836507', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/fr_dump.sql
+++ b/testdata/expected/dump/postgresql/fr_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'jd1f176@sfr.fr', 'Julie Dubois', 'jd1f176@sfr.fr', '+33 (0)4 99 01 04 00', 3),
 (4, 'nicolas.moreau', 'Nicolas Moreau', 'n480f87@laposte.net', '08 52 41 57 78', 2),
 (5, '0761923442', 'Lea Petit', 'l2f18fa@proton.me', '0761923442', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/gb_dump.sql
+++ b/testdata/expected/dump/postgresql/gb_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'h9d5504@gmail.com', 'Harry Jones', 'h9d5504@gmail.com', '+42 662 998 0000', 3),
 (4, 'isla.wilson', 'Isla Wilson', 'i3f3a84@protonmail.com', '0847 956 9153', 2),
 (5, '03708516272', 'George Taylor', 'geb413f@yahoo.co.uk', '03708516272', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/multi_dump.sql
+++ b/testdata/expected/dump/postgresql/multi_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'lukas.schmidt', 'Lukas Schmidt', 'lba36a4@web.de', '+45 50 2536 5878', 3),
 (4, '00 32 38 50 01', 'Camille Bernard', 'c404c10@free.fr', '00 32 38 50 01', 2),
 (5, 'ed763e6@telia.se', 'Erik Andersson', 'ed763e6@telia.se', '+48 7 135 40 65', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/ru_dump.sql
+++ b/testdata/expected/dump/postgresql/ru_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'sergey-volkov', 'Сергей Волков', 's608e39@bk.ru', '7 015 893 35 37', 3),
 (4, 'o87cc5e@rambler.ru', 'Ольга Романова', 'o87cc5e@rambler.ru', '+7 012 200 17 88', 2),
 (5, '72962859031', 'Елена Соколова', 'e18ddbb@list.ru', '72962859031', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/se_dump.sql
+++ b/testdata/expected/dump/postgresql/se_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'eaafd9e@gmail.com', 'Elsa Nilsson', 'eaafd9e@gmail.com', '+46 (0)37-224 559', 3),
 (4, 'oscar.lindberg', 'Oscar Lindberg', 'o8b7f6b@bahnhof.se', '070-715 472', 2),
 (5, '0911374868', 'Maja Karlsson', 'mf2f5a6@icloud.com', '0911374868', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/testdata/expected/dump/postgresql/us_dump.sql
+++ b/testdata/expected/dump/postgresql/us_dump.sql
@@ -5,6 +5,7 @@
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+
 CREATE TABLE public.tst_groups (
     id bigint PRIMARY KEY,
     code varchar(64) NOT NULL,
@@ -14,6 +15,7 @@ INSERT INTO public.tst_groups (id, code, title) VALUES
 (1, 'admins', 'Administrators'),
 (2, 'editors', 'Editorial Team'),
 (3, 'support', 'Customer Success');
+
 CREATE TABLE public.tst_users (
     id bigint PRIMARY KEY,
     login varchar(255) NOT NULL,
@@ -28,6 +30,7 @@ INSERT INTO public.tst_users (id, login, name, email, phone, group_id) VALUES
 (3, 'me4e8d5@outlook.com', 'Mason Hall', 'me4e8d5@outlook.com', '498-532-0536', 3),
 (4, 'olivia.wright', 'Olivia Wright', 'o1ca5a2@proton.me', '+1 093 785 8184', 2),
 (5, '3465230742', 'Noah Davis', 'n989ba1@icloud.com', '3465230742', 1);
+
 CREATE TABLE public.tst_posts (
     id bigint PRIMARY KEY,
     code varchar(128) NOT NULL,

--- a/tools/testdata_generator/main.go
+++ b/tools/testdata_generator/main.go
@@ -596,15 +596,13 @@ func joinPostgresPosts(posts []post) string {
 
 func maskContent(content string) string {
 	parts := strings.SplitAfter(content, "\n")
-	filtered := make([]string, 0, len(parts))
+	masked := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = emailRegex.ReplaceAllStringFunc(part, maskEmail)
 		part = phoneRegex.ReplaceAllStringFunc(part, maskPhone)
-		if strings.TrimSpace(part) != "" {
-			filtered = append(filtered, part)
-		}
+		masked = append(masked, part)
 	}
-	return strings.Join(filtered, "")
+	return strings.Join(masked, "")
 }
 
 func maskEmail(email string) string {


### PR DESCRIPTION
## Summary

Adds a dialect layer so table skipping and field-aware masking work consistently across dump formats instead of only MySQL-style `INSERT INTO \`table\`` lines.

- New `--db-format` CLI flag and `db_format` config field: `auto|mysql|postgresql|oracle|mssql|sqlite|firebird`. The flag overrides the config; the default is content-based auto-detection with a safe fallback (full-line regex masking + warning, selective filtering disabled) when the dialect cannot be determined.
- `DialectParser` interface; the existing MySQL logic moved behind it unchanged in behavior.
- **PostgreSQL**: `COPY ... FROM stdin` blocks are masked by column index (`\N` untouched), skip-listed tables drop the whole block including the `\.` terminator; multi-line `INSERT ... (cols) VALUES` statements are supported.
- **Oracle / MSSQL / SQLite / Firebird**: shared INSERT statement processor with quoted/bracketed identifier handling (`[dbo].[t]`, `"t"`), `GO` separators and statements without `;`; SQLite column positions are resolved from `CREATE TABLE` because its inserts carry no column list.
- Config table names match both plain (`tst_users`) and schema-qualified (`public.tst_users`) forms.

## Bug fixes folded into the refactor

- Selective mode no longer double-masks values when both `--mask-email` and `--mask-phone` are enabled (the line used to be processed twice).
- Selective mode no longer drops the trailing newline when rebuilding INSERT lines.
- Blank input lines are preserved in the output; expected fixtures regenerated (the diff is blank lines only, masking output is byte-identical).
- A final line without a trailing newline is no longer lost at EOF.

## Testing

- `make check` (gofmt, vet, golangci-lint, govulncheck) and `go test ./...` green.
- New `dialect_test.go`: all dialects, COPY masking/skip, schema-qualified names, multi-line inserts, auto-detection incl. buffered replay and generic fallback, blank-line preservation.
- Manual E2E: PostgreSQL COPY dump through the built binary — auto-detection, per-column masking, skip block removal, `--db-format` override and invalid-value error all verified.

## Docs

README (EN + RU sections) and `maskdump.conf.example` updated.

Binary-affecting `feat`: merging this will legitimately open the 0.4.0 release PR per the version discipline rules.