### PR TITLE
ci(release): run release-please with a PAT so CI triggers on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,6 @@ jobs:
     - id: release
       uses: googleapis/release-please-action@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         config-file: release-please-config.json
         manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Release PRs created by release-please with the default `GITHUB_TOKEN` don't get CI runs (GitHub blocks workflow triggers from `GITHUB_TOKEN`-created PRs to prevent recursion) — the 0.4.0 release PR (#18) had to be merged with its CI stuck in `action_required`.

Switch the release-please action to the `RELEASE_PLEASE_TOKEN` fine-grained PAT so release PRs are opened by a real actor and CI runs on them normally.

Non-releasing `ci:` change per docs/releasing.md version discipline.