### PR TITLE
fix(runtime): drop /tmp init log, stop wiping cache on startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -398,14 +398,21 @@ func checkFileAccess(path string, checkWrite bool) error {
 	}
 
 	if checkWrite {
-		// Checking the possibility of writing to the directory
-		if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		// Probe write access without touching existing content: the path
+		// may be a live file (e.g. the cache), so O_TRUNC must not be used.
+		_, statErr := os.Stat(path)
+		existed := statErr == nil
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
 			return fmt.Errorf("there is no write access to %s: %v", path, err)
 		}
-		// Delete the temporary file if it was created
-		if info, err := os.Stat(path); err == nil && info.Size() == 0 {
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed to close %s: %v", path, err)
+		}
+		// Remove the file only if the probe created it.
+		if !existed {
 			if err := os.Remove(path); err != nil {
-				return fmt.Errorf("failed to remove temp file %s: %v", path, err)
+				return fmt.Errorf("failed to remove probe file %s: %v", path, err)
 			}
 		}
 	} else if path != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -102,3 +102,36 @@ func TestLoadConfigRejectsAliasConflicts(t *testing.T) {
 		})
 	}
 }
+
+// Regression: the write-access probe used to truncate and delete an existing
+// file at the checked path, wiping the masking cache on every startup.
+func TestCheckFileAccessPreservesExistingContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.json")
+	content := `{"emails":{"a@b.com":"masked@b.com"},"phones":{}}`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	if err := checkFileAccess(path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to survive the probe: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("expected content preserved, got: %q", got)
+	}
+}
+
+func TestCheckFileAccessRemovesProbeFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.json")
+
+	if err := checkFileAccess(path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected probe file removed when it did not exist before, stat err: %v", err)
+	}
+}

--- a/maskdump.go
+++ b/maskdump.go
@@ -74,7 +74,9 @@ const (
 
 var logger *Logger
 
-// Check validates that the logger is ready for writes.
+// Check validates that the logger is ready for writes. The file is already
+// opened for writing by NewLogger; syncing validates the descriptor without
+// polluting the log with blank lines.
 func (l *Logger) Check() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -83,8 +85,7 @@ func (l *Logger) Check() error {
 		return fmt.Errorf("log file not opened")
 	}
 
-	_, err := l.file.WriteString("\n")
-	return err
+	return l.file.Sync()
 }
 
 // NewLogger creates a new Logger based on configuration.
@@ -636,42 +637,23 @@ func main() {
 		}()
 	}
 
-	// Temporary logger for initialization errors
-	initLogger, err := NewLogger(LogConfig{
-		Path:  "/tmp/maskdump_init.log", // temporary file
-		Level: "error",
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to create init logger: %v\n", err)
-		os.Exit(1)
-	}
-	defer func() {
-		if err := initLogger.Close(); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to close init logger: %v\n", err)
-		}
-		if err := os.Remove("/tmp/maskdump_init.log"); err != nil && !os.IsNotExist(err) {
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to remove init log file: %v\n", err)
-		}
-	}()
-
-	// Load configuration
+	// Until the main logger is initialized from the config, stderr is the
+	// only diagnostics channel: the log path itself comes from the config.
 	if err := LoadConfig(config.configFile); err != nil {
-		initLogger.Error("Config error: %v", err)
 		_, _ = fmt.Fprintf(os.Stderr, "Config error: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Checking if the log directory exists
 	if err := os.MkdirAll(filepath.Dir(AppConfig.Logging.Path), 0755); err != nil {
-		initLogger.Error("Failed to create log directory: %v", err)
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Now we initialize the main logger from the config
+	var err error
 	logger, err = NewLogger(AppConfig.Logging)
 	if err != nil {
-		initLogger.Error("Failed to initialize main logger: %v", err)
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize main logger: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Three fixes for side-effectful bootstrap code, found while auditing the hardcoded temp-file usage.

## Remove the `/tmp/maskdump_init.log` bootstrap logger

The init logger existed to capture errors before the main logger (whose path lives in the config) is available, but in practice:

- **on success** the file was created and immediately deleted — pure overhead;
- **on init errors** it was *leaked* in /tmp, because `os.Exit(1)` bypasses the cleanup `defer` — while the same message was already printed to stderr in every call site.

On top of that it was a fixed, predictable path in a world-writable directory: parallel maskdump instances (a normal pipeline scenario) shared and deleted each other's file, and the pattern is a textbook CWE-377. Init errors now go to stderr only — standard behavior for a pipeline filter.

## Stop destroying the cache on every startup

`checkFileAccess` probed write access with `os.WriteFile(path, []byte(""))`, which **truncates an existing file**, and then removed it because its size was 0. The masking cache was therefore wiped on every startup and cached replacements never survived a restart (invisible from outside only because masks are derived from md5/sha256 of the value). The probe now opens the file without `O_TRUNC` and removes it only if the probe itself created it. Verified E2E: the cache now persists and accumulates mappings across runs.

## `Logger.Check` no longer pollutes the log

It wrote a bare `"\n"` into the log file on every start; it now syncs the descriptor instead.

## Testing

- New regression tests: `TestCheckFileAccessPreservesExistingContent`, `TestCheckFileAccessRemovesProbeFile`.
- `make check` and full `go test ./...` green.
- E2E verified: no `/tmp/maskdump_init.log` on success or failure (error still on stderr), cache survives and accumulates across two runs, log contains no blank lines.